### PR TITLE
docs: clarify README and tweak popup wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# Deported Kit
+# Dported
 
-A kit for people who have been deported or are navigating life across borders. These tools help with everyday challenges like understanding foreign prices, converting units. 
 
 I'm building this for myself first, I've been deported to India from the United States. So, I need help calculating the price of things from INR to USD.
 
 For example, if I see a price of 100 INR on a website, I want to know how much that is in USD. Keeping the iOS calculator open in currency conversion mode is not that much fun. 
+
+I'm also going to need help with unit conversions. For example, cm to inches, kg to lbs, and Fahrenheit to Celsius.. etc etc.
 
 ## What's Included
 
@@ -23,9 +24,10 @@ See the [chrome-extension README](./chrome-extension/README.md) for installation
 
 ## Planned Tools
 
+- Unit converter (cm/inches, kg/lbs, temperatures)
+
 - Firefox extension
 - Safari extension
-- Unit converter (cm/inches, kg/lbs, temperatures)
 
 ## Contributing
 

--- a/chrome-extension/src/popup/popup.js
+++ b/chrome-extension/src/popup/popup.js
@@ -106,7 +106,7 @@ function updateRateDisplay() {
       month: "short",
       day: "numeric",
     });
-    lastUpdatedEl.textContent = `Exchange Rate Updated at: ${dateStr} at ${timeStr}`;
+    lastUpdatedEl.textContent = `Exchange Rate Updated on: ${dateStr} at ${timeStr}`;
   }
 }
 


### PR DESCRIPTION
Update user-facing text for clarity and expand README content.

- chrome-extension: change "Exchange Rate Updated at" to
  "Exchange Rate Updated on" in popup to use a more natural
  preposition with a date/time string.
- README: rename project title from "Deported Kit" to "Dported"
  and expand the introduction to mention planned unit conversion
  features (cm↔in, kg↔lb, °F↔°C). Remove duplicate planned-tool
  entry and add spacing for readability.

These changes improve clarity for users and clean up duplicate
entries in the planned tools list.