### PR TITLE
feat: improve price hover handling and INR detection

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Converter",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Converts prices and other units from one currency to another, or performs unit conversions",
   "permissions": ["storage", "activeTab"],
   "host_permissions": ["https://api.exchangerate-api.com/*"],

--- a/chrome-extension/src/content/content.js
+++ b/chrome-extension/src/content/content.js
@@ -215,18 +215,29 @@
    * Set up event listeners for price hover
    */
   function setupEventListeners() {
-    // Use event delegation on document body
-    document.body.addEventListener('mouseenter', (e) => {
-      if (e.target.classList && e.target.classList.contains('currency-converter-price')) {
-        showTooltip(e.target);
-      }
-    }, true);
+    // Track currently hovered price element to avoid re-triggering
+    let currentPriceEl = null;
 
-    document.body.addEventListener('mouseleave', (e) => {
-      if (e.target.classList && e.target.classList.contains('currency-converter-price')) {
-        hideTooltip();
+    // Use mouseover/mouseout for proper event delegation (they bubble)
+    document.body.addEventListener('mouseover', (e) => {
+      const priceEl = e.target.closest('.currency-converter-price');
+      if (priceEl && priceEl !== currentPriceEl) {
+        currentPriceEl = priceEl;
+        showTooltip(priceEl);
       }
-    }, true);
+    });
+
+    document.body.addEventListener('mouseout', (e) => {
+      const priceEl = e.target.closest('.currency-converter-price');
+      if (priceEl) {
+        // Check if we're moving to another element inside the same price container
+        const relatedTarget = e.relatedTarget;
+        if (!relatedTarget || !priceEl.contains(relatedTarget)) {
+          currentPriceEl = null;
+          hideTooltip();
+        }
+      }
+    });
 
     // Listen for settings changes
     chrome.storage.onChanged.addListener((changes, namespace) => {

--- a/chrome-extension/src/content/detector.js
+++ b/chrome-extension/src/content/detector.js
@@ -193,6 +193,16 @@ const PriceDetector = {
         // Selector might be invalid, ignore
       }
     });
+
+    // Process generic price selectors (for IKEA, etc.)
+    genericSelectors.forEach(selector => {
+      try {
+        const elements = root.querySelectorAll(selector);
+        elements.forEach(el => this.processStructuredPriceElement(el));
+      } catch (e) {
+        // Selector might be invalid, ignore
+      }
+    });
   },
 
   /**
@@ -213,8 +223,8 @@ const PriceDetector = {
     let amount = null;
     let currency = null;
 
-    // Check for INR patterns
-    const inrMatch = text.match(/₹\s*([\d,]+(?:\.\d{1,2})?)/);
+    // Check for INR patterns (₹ or Rs.)
+    const inrMatch = text.match(/(?:₹|Rs\.?)\s*([\d,]+(?:\.\d{1,2})?)/i);
     if (inrMatch) {
       currency = 'INR';
       amount = parseFloat(inrMatch[1].replace(/,/g, ''));
@@ -222,8 +232,8 @@ const PriceDetector = {
 
     // Check for just numbers with rupee symbol somewhere in parent
     if (!currency) {
-      const hasRupeeSymbol = text.includes('₹') ||
-        (element.closest && element.closest('[class*="price"]')?.textContent.includes('₹'));
+      const hasRupeeSymbol = text.includes('₹') || /Rs\.?/i.test(text) ||
+        (element.closest && /₹|Rs\.?/i.test(element.closest('[class*="price"]')?.textContent || ''));
       const numberMatch = text.match(/^[\d,]+(?:\.\d{1,2})?$/);
       if (hasRupeeSymbol && numberMatch) {
         currency = 'INR';

--- a/chrome-extension/src/content/tooltip.css
+++ b/chrome-extension/src/content/tooltip.css
@@ -3,12 +3,12 @@
 /* Detected price styling - subtle underline indicator */
 .currency-converter-price {
   cursor: pointer;
-  border-bottom: 1px dotted rgba(100, 100, 100, 0.5);
+  border-bottom: 1px dotted rgba(100, 100, 100, 0.2);
   transition: border-color 0.2s ease;
 }
 
 .currency-converter-price:hover {
-  border-bottom-color: rgba(66, 133, 244, 0.8);
+  border-bottom-color: rgba(66, 133, 244, 0.5);
 }
 
 /* Tooltip container */


### PR DESCRIPTION
- Refactor event delegation to use mouseover/mouseout and track the currently hovered price element to avoid repeated tooltip re-triggering.
- Add relatedTarget checks on mouseout so tooltips only hide when truly leaving the price element (not when moving to a child), improving hover stability and UX.
 Enhance price detection to recognize INR variants like "Rs." in addition to the rupee symbol.
- Expand selector processing to include generic/structured price selectors (e.g., IKEA) to reduce false negatives.
- Tweak tooltip visuals: lower underline opacity and reduce hover border color intensity.
- Bump extension version to 1.0.2 in manifest.

Closes #3