### PR TITLE
feat: rebrand extension to "BrowseAbroad" and clarify scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Dported is a collection of tools for people navigating life across borders, starting with currency and unit conversion utilities. Currently contains a Chrome extension; Firefox and Safari extensions are planned.
+BrowseAbroad is a collection of tools for people navigating life across borders, starting with currency and unit conversion utilities. Currently contains a Chrome extension; Firefox and Safari extensions are planned.
 
 ## Repository Structure
 
 ```
-dported/
+BrowseAbroad/
 ├── chrome-extension/    # Currency/unit converter Chrome extension
 │   └── CLAUDE.md        # Detailed extension-specific guidance
 └── README.md

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-# Dported
+# BrowseAbroad
 
+A collection of tools for navigating websites across borders, starting with currency and unit conversion utilities.
 
-I'm building this for myself first, I've been deported to India from the United States. So, I need help calculating the price of things from INR to USD.
-
-For example, if I see a price of 100 INR on a website, I want to know how much that is in USD. Keeping the iOS calculator open in currency conversion mode is not that much fun. 
+I built this for myself while living between countries. I needed an easy way to compare prices between INR and USD without constantly using a calculator. 
 
 I'm also going to need help with unit conversions. For example, cm to inches, kg to lbs, and Fahrenheit to Celsius.. etc etc.
 

--- a/chrome-extension/README.md
+++ b/chrome-extension/README.md
@@ -1,6 +1,6 @@
-# Unit Converter Chrome Extension
+# BrowseAbroad Chrome Extension
 
-A Chrome extension that detects measurement units on a web page and shows unit conversions on hover.
+A Chrome extension that detects prices and measurement units on web pages and shows conversions on hover.
 
 99% of this code was written by Claude Code, hopefully it doesn't start buying things on your behalf.
 

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "Converter",
+  "name": "BrowseAbroad",
   "version": "1.0.2",
-  "description": "Converts prices and other units from one currency to another, or performs unit conversions",
+  "description": "Currency and unit converter for navigating life across borders",
   "permissions": ["storage", "activeTab"],
   "host_permissions": ["https://api.exchangerate-api.com/*"],
   "background": {

--- a/chrome-extension/src/popup/popup.html
+++ b/chrome-extension/src/popup/popup.html
@@ -3,13 +3,13 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Dported Currency Converter</title>
+        <title>BrowseAbroad</title>
         <link rel="stylesheet" href="popup.css" />
     </head>
     <body>
         <div class="popup-container">
             <header class="popup-header">
-                <h1>Dported Currency Converter</h1>
+                <h1>BrowseAbroad</h1>
                 <label class="toggle-switch">
                     <input type="checkbox" id="enabledToggle" checked />
                     <span class="toggle-slider"></span>


### PR DESCRIPTION
- Rename and rebrand the project and Chrome extension from "Dported"/"Converter" to "BrowseAbroad"
- Update popup title/header, README, and CLAUDE.md to use the new name
- Change user-facing metadata and copy to reflect broader scope (detects prices and measurement units)
- Ensure extension shows conversions on hover for both prices and units
- Refine README intro to explain intent (comparing prices across INR/USD and unit conversions)
- Leave version number unchanged; keep manifest description and permissions consistent