### PR TITLE
chore(git): add comprehensive .gitignore for macOS, editors,

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,53 @@
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+.Spotlight-V100
+.Trashes
+
+# IDEs and Editors
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.project
+.settings/
+*.sublime-project
+*.sublime-workspace
+
+# Node.js (for future tools/scripts)
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json
+yarn.lock
+
+# Logs
+logs/
+*.log
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Temporary files
+*.tmp
+*.temp
+.cache/
+
+# Chrome extension artifacts
+*.crx
+*.pem
+*.zip
+
+# GitButler (managed by GitButler itself)
+.git/gitbutler/
+
+# Testing
+coverage/
+.nyc_output/


### PR DESCRIPTION
and common artifacts

Add a comprehensive .gitignore listing macOS system files, IDE/editor
and swap files, Node.js artifacts, logs, environment files, temporary
and cache files, Chrome extension build artifacts, GitButler-managed
files, and test coverage outputs.

This prevents accidental inclusion of OS metadata, editor state,
build artifacts, secrets in .env files, and transient or generated
files in the repository, reducing noise in commits and protecting
sensitive/local configuration.