### PR TITLE
✨ docs: clarify CLAUDE.md instructions and testing commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,15 +21,18 @@ The main project is a Manifest V3 Chrome extension that detects prices on web pa
 
 ### Development
 
-**No build step required** - pure vanilla JavaScript. After making changes:
-1. Go to `chrome://extensions`
-2. Click the reload icon on the extension
+**No build step required** - pure vanilla JavaScript. After changes, reload at `chrome://extensions`.
 
 ### Testing
 
-1. Load unpacked extension from `chrome-extension/` folder
-2. Test on Amazon India/US or other e-commerce sites
-3. Check DevTools console for errors
+```bash
+cd chrome-extension
+npm test                    # Run all unit tests
+npm run test:watch          # Watch mode
+npm run test:coverage       # Coverage report
+```
+
+For manual testing, load unpacked extension and test on Amazon or other e-commerce sites.
 
 ### Key Files
 

--- a/chrome-extension/CLAUDE.md
+++ b/chrome-extension/CLAUDE.md
@@ -1,6 +1,6 @@
-# Claude Code Context - Chrome Extension
+# CLAUDE.md
 
-This file provides context for Claude Code when working on the Chrome extension.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Architecture
 
@@ -89,4 +89,14 @@ manifest.json loads:
 
 ## Commands
 
-No build step required - pure vanilla JS. Just reload extension after changes.
+**No build step required** - pure vanilla JavaScript. After changes, reload the extension at `chrome://extensions`.
+
+### Testing
+```bash
+npm test                    # Run all tests once
+npm run test:watch          # Run tests in watch mode
+npm run test:coverage       # Run tests with coverage report
+npx vitest tests/unit/converters.test.js  # Run a single test file
+```
+
+Tests use vitest with jsdom environment. Test files are in `tests/unit/`.


### PR DESCRIPTION
Update and expand README-style documentation for the Chrome
extension to improve clarity and add explicit test instructions.

- Normalize filename header to "CLAUDE.md" and clarify the scope:
  explain guidance is for Claude Code (claude.ai/code) and working with
  repository code.
- Rephrase the "No build step required" note for conciseness and to
  instruct reloading at chrome://extensions.
- Add a detailed "Testing" section with concrete npm/vitest commands:
  npm test, npm run test:watch, npm run test:coverage, and an example
  npx vitest command to run a single test file.
- Provide guidance for manual testing (load unpacked extension and
  test on Amazon or other e-commerce sites).
- Wrap the commands in code blocks for readability and indicate test
  environment (vitest with jsdom) and test file location.