### PR TITLE
✨ style: improve tooltip CSS formatting and z-index handling

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "BrowseAbroad",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Currency and unit converter for navigating life across borders",
   "permissions": ["storage", "activeTab"],
   "host_permissions": ["https://api.exchangerate-api.com/*"],

--- a/chrome-extension/src/content/detector.js
+++ b/chrome-extension/src/content/detector.js
@@ -9,8 +9,8 @@ const PriceDetector = {
     INR: [
       // ₹1,234.56 or ₹ 1,234.56
       /₹\s*([\d,]+(?:\.\d{1,2})?)/g,
-      // Rs. 1,234.56 or Rs 1,234.56
-      /Rs\.?\s*([\d,]+(?:\.\d{1,2})?)/gi,
+      // Rs. 1,234.56 or Rs 1,234.56 (word boundary prevents matching "hours 20")
+      /\bRs\.?\s*([\d,]+(?:\.\d{1,2})?)/gi,
       // INR 1,234.56
       /INR\s*([\d,]+(?:\.\d{1,2})?)/gi
     ],
@@ -34,7 +34,7 @@ const PriceDetector = {
     // Create a combined pattern that captures the full price string
     const inrPatterns = [
       '₹\\s*[\\d,]+(?:\\.\\d{1,2})?',
-      'Rs\\.?\\s*[\\d,]+(?:\\.\\d{1,2})?',
+      '\\bRs\\.?\\s*[\\d,]+(?:\\.\\d{1,2})?',
       'INR\\s*[\\d,]+(?:\\.\\d{1,2})?'
     ];
     const usdPatterns = [
@@ -224,7 +224,7 @@ const PriceDetector = {
     let currency = null;
 
     // Check for INR patterns (₹ or Rs.)
-    const inrMatch = text.match(/(?:₹|Rs\.?)\s*([\d,]+(?:\.\d{1,2})?)/i);
+    const inrMatch = text.match(/(?:₹|\bRs\.?)\s*([\d,]+(?:\.\d{1,2})?)/i);
     if (inrMatch) {
       currency = 'INR';
       amount = parseFloat(inrMatch[1].replace(/,/g, ''));
@@ -232,8 +232,8 @@ const PriceDetector = {
 
     // Check for just numbers with rupee symbol somewhere in parent
     if (!currency) {
-      const hasRupeeSymbol = text.includes('₹') || /Rs\.?/i.test(text) ||
-        (element.closest && /₹|Rs\.?/i.test(element.closest('[class*="price"]')?.textContent || ''));
+      const hasRupeeSymbol = text.includes('₹') || /\bRs\.?/i.test(text) ||
+        (element.closest && /₹|\bRs\.?/i.test(element.closest('[class*="price"]')?.textContent || ''));
       const numberMatch = text.match(/^[\d,]+(?:\.\d{1,2})?$/);
       if (hasRupeeSymbol && numberMatch) {
         currency = 'INR';

--- a/chrome-extension/src/content/tooltip.css
+++ b/chrome-extension/src/content/tooltip.css
@@ -2,123 +2,132 @@
 
 /* Detected price styling - subtle underline indicator */
 .currency-converter-price {
-  cursor: pointer;
-  border-bottom: 1px dotted rgba(100, 100, 100, 0.2);
-  transition: border-color 0.2s ease;
+    cursor: pointer;
+    border-bottom: 1px dotted rgba(100, 100, 100, 0.2);
+    transition: border-color 0.2s ease;
+    /* Ensure price elements are above card overlays (e.g., Expedia's uitk-card-link) */
+    position: relative;
+    z-index: 5;
 }
 
 .currency-converter-price:hover {
-  border-bottom-color: rgba(66, 133, 244, 0.5);
+    border-bottom-color: rgba(66, 133, 244, 0.5);
 }
 
 /* Tooltip container */
 .currency-converter-tooltip {
-  position: fixed;
-  z-index: 2147483647;
-  padding: 8px 12px;
-  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
-  color: #ffffff;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-  font-size: 13px;
-  font-weight: 500;
-  line-height: 1.4;
-  border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25), 0 2px 4px rgba(0, 0, 0, 0.15);
-  pointer-events: none;
-  opacity: 0;
-  transform: translateY(4px);
-  transition: opacity 0.15s ease, transform 0.15s ease;
-  white-space: nowrap;
-  max-width: 280px;
+    position: fixed;
+    z-index: 2147483647;
+    padding: 8px 12px;
+    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+    color: #ffffff;
+    font-family:
+        -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+        sans-serif;
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1.4;
+    border-radius: 6px;
+    box-shadow:
+        0 4px 12px rgba(0, 0, 0, 0.25),
+        0 2px 4px rgba(0, 0, 0, 0.15);
+    pointer-events: none;
+    opacity: 0;
+    transform: translateY(4px);
+    transition:
+        opacity 0.15s ease,
+        transform 0.15s ease;
+    white-space: nowrap;
+    max-width: 280px;
 }
 
 .currency-converter-tooltip.visible {
-  opacity: 1;
-  transform: translateY(0);
+    opacity: 1;
+    transform: translateY(0);
 }
 
 /* Tooltip arrow */
 .currency-converter-tooltip::before {
-  content: '';
-  position: absolute;
-  width: 0;
-  height: 0;
-  border: 6px solid transparent;
+    content: "";
+    position: absolute;
+    width: 0;
+    height: 0;
+    border: 6px solid transparent;
 }
 
 /* Arrow positioning - bottom tooltip (arrow on top) */
 .currency-converter-tooltip.position-bottom::before {
-  bottom: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  border-bottom-color: #1a1a2e;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border-bottom-color: #1a1a2e;
 }
 
 /* Arrow positioning - top tooltip (arrow on bottom) */
 .currency-converter-tooltip.position-top::before {
-  top: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  border-top-color: #16213e;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border-top-color: #16213e;
 }
 
 /* Tooltip content layout */
 .currency-converter-tooltip-content {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
 }
 
 /* Converted value (main) */
 .currency-converter-tooltip-value {
-  font-size: 15px;
-  font-weight: 600;
-  color: #4ade80;
+    font-size: 15px;
+    font-weight: 600;
+    color: #4ade80;
 }
 
 /* Original value and rate info */
 .currency-converter-tooltip-original {
-  font-size: 11px;
-  color: rgba(255, 255, 255, 0.6);
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.6);
 }
 
 /* Rate info */
 .currency-converter-tooltip-rate {
-  font-size: 10px;
-  color: rgba(255, 255, 255, 0.4);
-  margin-top: 2px;
+    font-size: 10px;
+    color: rgba(255, 255, 255, 0.4);
+    margin-top: 2px;
 }
 
 /* Disabled state message */
 .currency-converter-tooltip-disabled {
-  color: rgba(255, 255, 255, 0.5);
-  font-style: italic;
+    color: rgba(255, 255, 255, 0.5);
+    font-style: italic;
 }
 
 /* Loading state */
 .currency-converter-tooltip-loading {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
 }
 
 .currency-converter-tooltip-loading::after {
-  content: '';
-  width: 12px;
-  height: 12px;
-  border: 2px solid rgba(255, 255, 255, 0.2);
-  border-top-color: #4ade80;
-  border-radius: 50%;
-  animation: currency-converter-spin 0.8s linear infinite;
+    content: "";
+    width: 12px;
+    height: 12px;
+    border: 2px solid rgba(255, 255, 255, 0.2);
+    border-top-color: #4ade80;
+    border-radius: 50%;
+    animation: currency-converter-spin 0.8s linear infinite;
 }
 
 @keyframes currency-converter-spin {
-  to {
-    transform: rotate(360deg);
-  }
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 /* Error state */
 .currency-converter-tooltip-error {
-  color: #f87171;
+    color: #f87171;
 }

--- a/chrome-extension/tests/unit/detector.test.js
+++ b/chrome-extension/tests/unit/detector.test.js
@@ -461,6 +461,164 @@ describe('PriceDetector', () => {
     });
   });
 
+  describe('False Positive Prevention - Rs word boundary', () => {
+    describe('should NOT match "rs" within words (false positives)', () => {
+      it('should not match "12 hours 20 minutes"', () => {
+        const container = document.createElement('div');
+        container.textContent = '12 hours 20 minutes';
+        document.body.appendChild(container);
+
+        PriceDetector.scanDOM(container);
+        const prices = container.querySelectorAll('.currency-converter-price');
+
+        expect(prices.length).toBe(0);
+        container.remove();
+      });
+
+      it('should not match "3 hours 5 minutes"', () => {
+        const container = document.createElement('div');
+        container.textContent = '3 hours 5 minutes';
+        document.body.appendChild(container);
+
+        PriceDetector.scanDOM(container);
+        const prices = container.querySelectorAll('.currency-converter-price');
+
+        expect(prices.length).toBe(0);
+        container.remove();
+      });
+
+      it('should not match "yours 50"', () => {
+        const container = document.createElement('div');
+        container.textContent = 'yours 50';
+        document.body.appendChild(container);
+
+        PriceDetector.scanDOM(container);
+        const prices = container.querySelectorAll('.currency-converter-price');
+
+        expect(prices.length).toBe(0);
+        container.remove();
+      });
+
+      it('should not match "colors 100"', () => {
+        const container = document.createElement('div');
+        container.textContent = 'colors 100';
+        document.body.appendChild(container);
+
+        PriceDetector.scanDOM(container);
+        const prices = container.querySelectorAll('.currency-converter-price');
+
+        expect(prices.length).toBe(0);
+        container.remove();
+      });
+    });
+
+    describe('should still match valid Rs patterns', () => {
+      it('should match "Rs. 100" at start of string', () => {
+        const container = document.createElement('div');
+        container.textContent = 'Rs. 100';
+        document.body.appendChild(container);
+
+        PriceDetector.scanDOM(container);
+        const prices = container.querySelectorAll('.currency-converter-price');
+
+        expect(prices.length).toBe(1);
+        expect(prices[0].getAttribute('data-amount')).toBe('100');
+        container.remove();
+      });
+
+      it('should match "Rs 100" without dot', () => {
+        const container = document.createElement('div');
+        container.textContent = 'Rs 100';
+        document.body.appendChild(container);
+
+        PriceDetector.scanDOM(container);
+        const prices = container.querySelectorAll('.currency-converter-price');
+
+        expect(prices.length).toBe(1);
+        expect(prices[0].getAttribute('data-amount')).toBe('100');
+        container.remove();
+      });
+
+      it('should match "RS. 100" uppercase', () => {
+        const container = document.createElement('div');
+        container.textContent = 'RS. 100';
+        document.body.appendChild(container);
+
+        PriceDetector.scanDOM(container);
+        const prices = container.querySelectorAll('.currency-converter-price');
+
+        expect(prices.length).toBe(1);
+        expect(prices[0].getAttribute('data-amount')).toBe('100');
+        container.remove();
+      });
+
+      it('should match "rs 100" lowercase', () => {
+        const container = document.createElement('div');
+        container.textContent = 'rs 100';
+        document.body.appendChild(container);
+
+        PriceDetector.scanDOM(container);
+        const prices = container.querySelectorAll('.currency-converter-price');
+
+        expect(prices.length).toBe(1);
+        expect(prices[0].getAttribute('data-amount')).toBe('100');
+        container.remove();
+      });
+
+      it('should match "Rs. 1,00,000" with Indian comma format', () => {
+        const container = document.createElement('div');
+        container.textContent = 'Rs. 1,00,000';
+        document.body.appendChild(container);
+
+        PriceDetector.scanDOM(container);
+        const prices = container.querySelectorAll('.currency-converter-price');
+
+        expect(prices.length).toBe(1);
+        expect(prices[0].getAttribute('data-amount')).toBe('100000');
+        container.remove();
+      });
+
+      it('should match "Buy now for Rs. 500" after text', () => {
+        const container = document.createElement('div');
+        container.textContent = 'Buy now for Rs. 500';
+        document.body.appendChild(container);
+
+        PriceDetector.scanDOM(container);
+        const prices = container.querySelectorAll('.currency-converter-price');
+
+        expect(prices.length).toBe(1);
+        expect(prices[0].getAttribute('data-amount')).toBe('500');
+        container.remove();
+      });
+
+      it('should match "Price:Rs.250" after punctuation', () => {
+        const container = document.createElement('div');
+        container.textContent = 'Price:Rs.250';
+        document.body.appendChild(container);
+
+        PriceDetector.scanDOM(container);
+        const prices = container.querySelectorAll('.currency-converter-price');
+
+        expect(prices.length).toBe(1);
+        expect(prices[0].getAttribute('data-amount')).toBe('250');
+        container.remove();
+      });
+
+      it('should match "(Rs. 750)" in parentheses', () => {
+        const container = document.createElement('div');
+        container.textContent = '(Rs. 750)';
+        document.body.appendChild(container);
+
+        PriceDetector.scanDOM(container);
+        const prices = container.querySelectorAll('.currency-converter-price');
+
+        expect(prices.length).toBe(1);
+        expect(prices[0].getAttribute('data-amount')).toBe('750');
+        container.remove();
+      });
+    });
+  });
+
   describe('Regex Pattern Tests', () => {
     describe('combinedPattern', () => {
       it('should match INR patterns', () => {


### PR DESCRIPTION
- Add position: relative and z-index: 5 to .currency-converter-price to ensure prices appear above overlayed site elements (fixes tooltip coverage on pages like Expedia).
- Reformat .currency-converter-tooltip and related CSS rules for consistent indentation and multiline properties to improve readability and maintainability.
- Normalize string quoting in content declarations and loading spinner styles for consistency.
- Preserve existing tooltip behavior (visibility, arrow positioning, states, and animations) while making CSS easier to modify.

closes #9