### PR TITLE
fix(detector): correctly parse dollar prefixes and expand tests

### DIFF
--- a/chrome-extension/CLAUDE.md
+++ b/chrome-extension/CLAUDE.md
@@ -51,6 +51,7 @@ Uses `chrome.storage.sync`:
 - Amazon splits prices across elements - use `scanStructuredPrices()`
 - Check if element has `data-price-detected` already
 - Verify regex patterns in `combinedPattern`
+- Ensure `parsePrice()` strip regex handles all prefix variants — both `combinedPattern` (detection) and the strip regex in `parsePrice()` must agree on what's valid
 
 ### Tooltip Not Showing
 - Check if `settings.enabled` is true

--- a/chrome-extension/README.md
+++ b/chrome-extension/README.md
@@ -10,6 +10,7 @@ For example, go to https://www.amazon.in and look at prices, hover over a price 
 
 - Amazon India (https://www.amazon.in) (INR to USD)
 - Amazon US (https://www.amazon.com) (USD to INR)
+- Namecheap (https://www.namecheap.com) (USD to INR)
 - Dell India (https://www.dell.com/en-in) (INR to USD)
 - DailyObjects (https://www.dailyobjects.com/) (INR to USD)
 

--- a/chrome-extension/src/content/detector.js
+++ b/chrome-extension/src/content/detector.js
@@ -64,7 +64,7 @@ const PriceDetector = {
       amountStr = str.replace(/^(₹|Rs\.?|INR)\s*/i, '');
     } else if (/\$/.test(str) || /^USD/i.test(str) || /^US\$/i.test(str)) {
       currency = 'USD';
-      amountStr = str.replace(/^(US?\$|USD)\s*/i, '');
+      amountStr = str.replace(/^(US\$|USD|\$)\s*/i, '');
     }
 
     if (!currency || !amountStr) return null;

--- a/chrome-extension/tests/unit/detector.test.js
+++ b/chrome-extension/tests/unit/detector.test.js
@@ -72,10 +72,6 @@ describe('PriceDetector', () => {
     });
 
     describe('USD formats', () => {
-      // Note: The current parsePrice implementation has a regex issue where plain "$"
-      // symbols don't get stripped properly. The regex /^(US?\$|USD)\s*/ expects
-      // "U$", "US$", or "USD" but not plain "$". These tests document actual behavior.
-
       it('should parse USD prefix', () => {
         const result = PriceDetector.parsePrice('USD 50.00');
         expect(result).toEqual({
@@ -112,14 +108,40 @@ describe('PriceDetector', () => {
         });
       });
 
-      // Note: Plain $ format detection is limited - the code detects currency
-      // correctly but the replace regex doesn't strip the $ properly.
-      // These tests document the current behavior.
-      it('should detect $ symbol as USD currency', () => {
+      it('should parse $ symbol format', () => {
         const result = PriceDetector.parsePrice('$99.99');
-        // Currently returns null because the amount becomes "$99.99" after replace
-        // which fails parseFloat. This is a known limitation.
-        expect(result).toBeNull();
+        expect(result).toEqual({
+          amount: 99.99,
+          currency: 'USD',
+          original: '$99.99'
+        });
+      });
+
+      it('should parse $ with space', () => {
+        const result = PriceDetector.parsePrice('$ 100');
+        expect(result).toEqual({
+          amount: 100,
+          currency: 'USD',
+          original: '$ 100'
+        });
+      });
+
+      it('should parse $ with commas', () => {
+        const result = PriceDetector.parsePrice('$1,234.56');
+        expect(result).toEqual({
+          amount: 1234.56,
+          currency: 'USD',
+          original: '$1,234.56'
+        });
+      });
+
+      it('should parse $ with decimal', () => {
+        const result = PriceDetector.parsePrice('$10.50');
+        expect(result).toEqual({
+          amount: 10.5,
+          currency: 'USD',
+          original: '$10.50'
+        });
       });
     });
 


### PR DESCRIPTION
- Adjust parsePrice to strip dollar prefixes in the same order as detection, matching plain "$", "US$", then "USD" to avoid leftover "$" characters that broke parseFloat
- Update the strip regex to mirror the combined detection pattern
- Add and expand unit tests for multiple dollar formats: plain "$", "$ " (with space), commas like "$1,234.56", and decimals
- Remove outdated test comments documenting the previous limitation
- Document the regex requirement in CLAUDE.md
- Add Namecheap to the README examples

Closes #11