### PR TITLE
feat: document build, release, and linting workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,11 +19,15 @@ BrowseAbroad/
 ├── icons/                  # Extension icons
 ├── manifest.chrome.json    # Chrome manifest (build → dist/chrome/manifest.json)
 ├── manifest.firefox.json   # Firefox manifest (build → dist/firefox/manifest.json)
-├── scripts/                # Build scripts (build.js, bump-version.js)
+├── scripts/                # build.js, bump-version.js, create-icons.js
 ├── tests/                  # Vitest tests
+├── .github/workflows/      # ci.yml (lint+test on PR), release.yml (sign+publish on v* tag)
+├── LICENSE                 # MIT
 └── dist/                   # Build output (gitignored)
     ├── chrome/             # Loadable Chrome extension
-    └── firefox/            # Loadable Firefox extension
+    ├── firefox/            # Loadable Firefox extension
+    ├── browseabroad-chrome.zip   # Chrome Web Store upload
+    └── browseabroad-firefox.xpi  # AMO upload / sideload
 ```
 
 ## Architecture
@@ -56,7 +60,18 @@ pnpm build:firefox      # Build Firefox only → dist/firefox/
 pnpm dev                # Build both + watch for changes
 pnpm dev:chrome         # Build Chrome + watch
 pnpm dev:firefox        # Build Firefox + watch
+pnpm package            # Build + zip both → dist/browseabroad-{chrome.zip,firefox.xpi}
+pnpm package:firefox    # Build + zip Firefox only (XPI for AMO upload or sideload)
+pnpm package:chrome     # Build + zip Chrome only (zip for Chrome Web Store)
 ```
+
+### Lint (AMO pre-submission check)
+
+```bash
+pnpm lint:firefox       # Run Mozilla's addons-linter against dist/firefox
+```
+
+Run this before every AMO submission; it surfaces the same errors and warnings AMO will. Don't run web-ext lint against `dist/chrome` — it's a Firefox-targeted validator and produces false positives (missing `gecko.id`, missing `background.scripts` fallback) that don't apply to Chrome MV3.
 
 ### Development
 
@@ -77,8 +92,19 @@ Tests use vitest with jsdom environment. Test files are in `tests/unit/`.
 ### Version Bump
 
 ```bash
-pnpm run version:bump   # Bump version in manifests
+pnpm version:bump patch|minor|major   # Bumps both manifests + package.json in lockstep
 ```
+
+The bumper aborts loudly if the three files disagree on the current version — reconcile manually, then re-run.
+
+### Release
+
+1. `pnpm version:bump patch` — updates all three version fields
+2. Commit, then `git tag v$(node -p "require('./package.json').version") && git push --tags`
+3. `.github/workflows/release.yml` runs: tests → build → `web-ext lint` → `web-ext sign --channel=unlisted` → attaches signed `.xpi` and `browseabroad-chrome.zip` to the GitHub Release.
+4. For AMO listing: download the signed XPI and submit at addons.mozilla.org → Submit a New Add-on.
+
+The signing step needs `WEB_EXT_API_KEY` and `WEB_EXT_API_SECRET` repo secrets — generate them at addons.mozilla.org → Developer Hub → Manage API Keys.
 
 ## Key Differences Between Platforms
 
@@ -106,9 +132,9 @@ All source code (`src/`) is identical for both platforms. The code uses `chrome.
 ### Supporting New E-commerce Sites
 Add site-specific selectors to `scanStructuredPrices()` in `src/content/detector.js`
 
-## Adding New Tools
+## Adding New Platforms
 
-This is a monorepo. Future tools (Safari extension, unit converters) should follow the same pattern of `manifest.<platform>.json` files sharing `src/`.
+Add `manifest.<platform>.json` at the repo root and a case in `scripts/build.js`. The single `src/` tree is shared.
 
 ## Common Issues
 
@@ -126,14 +152,15 @@ This is a monorepo. Future tools (Safari extension, unit converters) should foll
 - Same file as Chrome service worker — works because code doesn't use service-worker-specific APIs
 - Firefox's `background.scripts` with MV3 defaults to non-persistent event page
 
+### Firefox Manifest: don't unify the version floors
+- `manifest.firefox.json` deliberately splits `gecko.strict_min_version` (140.0 desktop) from `gecko_android.strict_min_version` (142.0 Android). Mozilla shipped `data_collection_permissions` support in those two different releases. Unifying to a single value re-introduces a `web-ext lint` warning either way.
+- `data_collection_permissions: { required: ["none"] }` is a forward-compat declaration — Mozilla treats its absence as a warning today and "will require it" for new submissions. Don't remove it as "unused config."
+
+### Don't use `innerHTML` in popup.js / content.js
+- All DOM construction uses `createElement` + `textContent` + `replaceChildren`. This isn't stylistic — `web-ext lint` flags every `innerHTML =` as `UNSAFE_VAR_ASSIGNMENT` and AMO reviewers flag accumulations of these warnings during manual review. If you need to add UI, follow the existing pattern (see `makePlaceholder` and `makeRateRow` helpers in `src/popup/popup.js`, and `make()` in `updateTooltipContent` in `src/content/content.js`).
+
 ## Persistent Firefox Install
 
-By default, Firefox only loads signed extensions. For local development that persists across restarts:
+The signed XPI from [GitHub Releases](https://github.com/vidluther/BrowseAbroad/releases) installs persistently in any Firefox.
 
-1. Install [Firefox Developer Edition](https://www.mozilla.org/firefox/developer/) (or Nightly)
-2. Open it, go to `about:config`, search `xpinstall.signatures.required`, set to `false`
-3. Run `pnpm package:firefox` to build and create the XPI
-4. In Firefox, go to `about:addons` → gear icon → "Install Add-on From File"
-5. Select `dist/browseabroad-firefox.xpi`
-
-The extension will now persist across restarts. Re-run `pnpm package:firefox` and re-install after code changes.
+For an unsigned **local** build to persist, you need Firefox Developer Edition or Nightly with `xpinstall.signatures.required = false` in `about:config`, then install `dist/browseabroad-firefox.xpi` via `about:addons` → gear → "Install Add-on From File". Stable Firefox refuses unsigned XPIs entirely.


### PR DESCRIPTION
Add comprehensive documentation for packaging, linting, and release processes. Document the new create-icons.js script, GitHub Actions workflows (ci.yml and release.yml), and the complete release pipeline including web-ext signing and AMO submission. Add platform-specific guidance for Firefox manifest version floors and innerHTML safety requirements. Clarify the monorepo pattern for adding new platforms and update version bump command documentation.